### PR TITLE
Improve response validation ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ It is inspired by [`apipie-rails`](https://github.com/Apipie/apipie-rails) and [
 - conveniently check request and response data against the declaration
 - offer an up-to-date OpenAPI export with minimal configuration
 
-## ⚠️ This is a work in progress - TODO:
-
-- ISO8601Time, ISO8601Date types
-- ResponseValidation: allow rendering scalars directly (e.g. `render json: 42`)
-
 ## Installation
 
 ```bash
@@ -139,9 +134,9 @@ The following type names are available by default and can be used as `type:`/`ar
 - `'Float'`
 - `'FreeForm'` - accepts and renders any JSON-serializable object, use with care
 - `'Integer'`
-- `'NoContentType'` - renders an empty object, for use with `status: :no_content`
+- `'NoContent'` - renders an empty object, for use with `status: :no_content`
 - `'String'`
-- `'Timestamp'` - renders a `Time` as unix timestamp integer and turns into incoming integers into a `Time`
+- `'Timestamp'` - renders a `Time` as unix timestamp integer and turns incoming integers into a `Time`
 - `'UUID'` - accepts and renders UUIDs
 - `'Date'` - accepts and renders a date string in ISO8601 format
 - `'Time'` - accepts and renders a time string in ISO8601 format

--- a/lib/taro/errors.rb
+++ b/lib/taro/errors.rb
@@ -1,4 +1,10 @@
-class Taro::Error < StandardError; end
+class Taro::Error < StandardError
+  def message
+    # clean up newlines introduced when setting the message with a heredoc
+    super.chomp.tr("\n", ' ')
+  end
+end
+
 class Taro::ArgumentError < Taro::Error; end
 class Taro::RuntimeError < Taro::Error; end
 class Taro::ValidationError < Taro::RuntimeError; end # not to be used directly

--- a/lib/taro/rails.rb
+++ b/lib/taro/rails.rb
@@ -12,7 +12,6 @@ module Taro::Rails
     buffered_declarations.clear
     declarations_map.clear
     RouteFinder.clear_cache
-    Taro::Types::BaseType.rendering = nil
-    Taro::Types::BaseType.used_in_response = nil
+    Taro::Types::BaseType.last_render = nil
   end
 end

--- a/lib/taro/rails/active_declarations.rb
+++ b/lib/taro/rails/active_declarations.rb
@@ -2,7 +2,7 @@ module Taro::Rails::ActiveDeclarations
   def apply(declaration:, controller_class:, action_name:)
     (declarations_map[controller_class] ||= {})[action_name] = declaration
     Taro::Rails::ParamParsing.install(controller_class:, action_name:)
-    Taro::Rails::ResponseValidation.install(controller_class:, action_name:)
+    Taro::Rails::ResponseValidation.install(controller_class:)
   end
 
   def declarations_map

--- a/lib/taro/rails/response_validation.rb
+++ b/lib/taro/rails/response_validation.rb
@@ -1,63 +1,13 @@
 module Taro::Rails::ResponseValidation
-  def self.install(controller_class:, action_name:)
-    return unless Taro.config.validate_response
+  def self.install(controller_class:)
+    controller_class.prepend(self) if Taro.config.validate_response
+  end
 
-    key = [controller_class, action_name]
-    return if installed[key]
-
-    installed[key] = true
-
-    controller_class.around_action(only: action_name) do |_, block|
-      Taro::Types::BaseType.rendering = nil
-      block.call
-      Taro::Rails::ResponseValidation.call(self)
-    ensure
-      Taro::Types::BaseType.rendering = nil
+  def render(*, **kwargs, &)
+    result = super
+    if (declaration = Taro::Rails.declaration_for(self))
+      Taro::Rails::ResponseValidator.call(self, declaration, kwargs[:json])
     end
-  end
-
-  def self.installed
-    @installed ||= {}
-  end
-
-  def self.call(controller)
-    declaration = Taro::Rails.declaration_for(controller)
-    nesting = declaration.return_nestings[controller.status]
-    expected = declaration.returns[controller.status]
-    if nesting
-      # case: `returns :some_nesting, type: 'SomeType'` (ad-hoc return type)
-      check_nesting(controller.response, nesting)
-      expected = expected.fields[nesting].type
-    end
-
-    check_expected_type_was_used(controller, expected)
-  end
-
-  def self.check_nesting(response, nesting)
-    return unless /json/.match?(response.media_type)
-
-    first_key = response.body.to_s[/\A{\s*"([^"]+)"/, 1]
-    first_key == nesting.to_s || raise(Taro::ResponseError, <<~MSG)
-      Expected response to be nested in "#{nesting}" key, but it was not.
-      (First JSON key in response: "#{first_key}".)
-    MSG
-  end
-
-  def self.check_expected_type_was_used(controller, expected)
-    used = Taro::Types::BaseType.rendering
-
-    if expected.nil?
-      raise(Taro::ResponseError, <<~MSG)
-        No matching return type declared in #{controller.class}##{controller.action_name}\
-        for status #{controller.status}.
-      MSG
-    end
-
-    used&.<=(expected) || raise(Taro::ResponseError, <<~MSG)
-      Expected #{controller.class}##{controller.action_name} to use #{expected}.render,
-      but #{used ? "#{used}.render" : 'no type render method'} was called.
-    MSG
-
-    Taro::Types::BaseType.used_in_response = used # for comparisons in specs
+    result
   end
 end

--- a/lib/taro/rails/response_validator.rb
+++ b/lib/taro/rails/response_validator.rb
@@ -1,0 +1,109 @@
+Taro::Rails::ResponseValidator = Struct.new(:controller, :declaration, :rendered) do
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    if declared_return_type < Taro::Types::ScalarType
+      check_scalar
+    elsif declared_return_type < Taro::Types::ListType &&
+          declared_return_type.item_type < Taro::Types::ScalarType
+      check_scalar_array
+    elsif declared_return_type < Taro::Types::EnumType
+      check_enum
+    else
+      check_custom_type
+    end
+  end
+
+  def declared_return_type
+    @declared_return_type ||= begin
+      return_type = declaration.returns[controller.status] ||
+                    fail_with('No return type declared for this status.')
+      nesting ? return_type.fields.fetch(nesting).type : return_type
+    end
+  end
+
+  def fail_with(message)
+    raise Taro::ResponseError, <<~MSG
+      Response validation error for
+      #{controller.class}##{controller.action_name}, code #{controller.status}":
+      #{message}
+    MSG
+  end
+
+  # support `returns :some_nesting, type: 'SomeType'` (ad-hoc return type)
+  def nesting
+    @nesting ||= declaration.return_nestings[controller.status]
+  end
+
+  def denest_rendered
+    assert_rendered_is_a_hash
+
+    if rendered.key?(nesting)
+      rendered[nesting]
+    elsif rendered.key?(nesting.to_s)
+      rendered[nesting.to_s]
+    else
+      fail_with_nesting_error
+    end
+  end
+
+  def assert_rendered_is_a_hash
+    rendered.is_a?(Hash) || fail_with("Expected Hash, got #{rendered.class}.")
+  end
+
+  def fail_with_nesting_error
+    fail_with "Expected key :#{nesting}, got: #{rendered.keys}."
+  end
+
+  # For scalar and enum types, we want to support e.g. `render json: 42`,
+  # and not require using the type as in `BeautifulNumbersEnum.render(42)`.
+  def check_scalar(type = declared_return_type, value = subject)
+    case type.openapi_type
+    when :integer, :number then value.is_a?(Numeric)
+    when :string           then value.is_a?(String) || value.is_a?(Symbol)
+    when :boolean          then [true, false].include?(value)
+    end || fail_with("Expected a #{type.openapi_type}, got: #{value.class}.")
+  end
+
+  def subject
+    @subject ||= nesting ? denest_rendered : rendered
+  end
+
+  def check_scalar_array
+    subject.is_a?(Array) || fail_with('Expected an Array.')
+    subject.empty? || check_scalar(declared_return_type.item_type, subject.first)
+  end
+
+  def check_enum
+    # coercion checks non-emptyness + enum match
+    declared_return_type.new(subject).coerce_response
+  rescue Taro::Error => e
+    fail_with(e.message)
+  end
+
+  # For complex/object types, we ensure conformance by checking whether
+  # the type was used for rendering. This has performance benefits compared
+  # to going over the structure a second time.
+  def check_custom_type
+    # Ignore types without a specified structure.
+    return if declared_return_type <= Taro::Types::ObjectTypes::FreeFormType
+    return if declared_return_type <= Taro::Types::ObjectTypes::NoContentType
+
+    strict_check_custom_type
+  end
+
+  def strict_check_custom_type
+    used_type, rendered_object_id = declared_return_type.last_render
+    used_type&.<=(declared_return_type) || fail_with(<<~MSG)
+      Expected to use #{declared_return_type}.render, but the last type rendered
+      was: #{used_type || 'no type'}.
+    MSG
+
+    rendered_object_id == subject.__id__ || fail_with(<<~MSG)
+      #{declared_return_type}.render was called, but the result
+      of this call was not used in the response.
+    MSG
+  end
+end

--- a/lib/taro/types/coercion.rb
+++ b/lib/taro/types/coercion.rb
@@ -56,15 +56,16 @@ module Taro::Types::Coercion
       @shortcuts ||= {
         # rubocop:disable Layout/HashAlignment - buggy cop
         'Boolean'   => Taro::Types::Scalar::BooleanType,
+        'Date'      => Taro::Types::Scalar::ISO8601DateType,
+        'DateTime'  => Taro::Types::Scalar::ISO8601DateTimeType,
         'Float'     => Taro::Types::Scalar::FloatType,
         'FreeForm'  => Taro::Types::ObjectTypes::FreeFormType,
         'Integer'   => Taro::Types::Scalar::IntegerType,
+        'NoContent' => Taro::Types::ObjectTypes::NoContentType,
         'String'    => Taro::Types::Scalar::StringType,
+        'Time'      => Taro::Types::Scalar::ISO8601DateTimeType,
         'Timestamp' => Taro::Types::Scalar::TimestampType,
         'UUID'      => Taro::Types::Scalar::UUIDv4Type,
-        'Date'      => Taro::Types::Scalar::ISO8601DateType,
-        'Time'      => Taro::Types::Scalar::ISO8601DateTimeType,
-        'DateTime'  => Taro::Types::Scalar::ISO8601DateTimeType,
         # rubocop:enable Layout/HashAlignment - buggy cop
       }.freeze
     end

--- a/lib/taro/types/enum_type.rb
+++ b/lib/taro/types/enum_type.rb
@@ -18,7 +18,7 @@ class Taro::Types::EnumType < Taro::Types::BaseType
     if self.class.values.include?(value)
       value
     else
-      input_error("must be one of #{self.class.values}")
+      input_error("must be #{self.class.values.map(&:inspect).join(' or ')}")
     end
   end
 
@@ -28,7 +28,7 @@ class Taro::Types::EnumType < Taro::Types::BaseType
     if self.class.values.include?(value)
       value
     else
-      response_error("must be one of #{self.class.values}")
+      response_error("must be #{self.class.values.map(&:inspect).join(' or ')}")
     end
   end
 

--- a/spec/taro/export/open_api_v3_spec.rb
+++ b/spec/taro/export/open_api_v3_spec.rb
@@ -9,7 +9,7 @@ describe Taro::Export::OpenAPIv3 do
     declaration.add_info 'My endpoint description'
     declaration.add_param :id, type: 'Integer', null: false
     declaration.add_param :foo, type: 'String', null: true
-    declaration.add_return type: 'Integer', code: 200, null: false, desc: 'okay'
+    declaration.add_return type: 'Integer', code: 200, desc: 'okay'
     declaration.add_return :errors, array_of: 'FailureType', code: 422, null: false, desc: 'bad'
     declaration.routes = [Taro::Rails::NormalizedRoute.new(mock_user_route)]
     declaration.add_openapi_names(

--- a/spec/taro/rails/declaration_spec.rb
+++ b/spec/taro/rails/declaration_spec.rb
@@ -79,7 +79,19 @@ describe Taro::Rails::Declaration do
     it 'raises for bad status' do
       expect do
         subject.add_return type: 'String', code: 999
-      end.to raise_error(Taro::Error, /status/)
+      end.to raise_error(Taro::ArgumentError, /status/)
+    end
+
+    it 'raises for top-level null' do
+      expect do
+        subject.add_return code: 200, type: 'String', null: true
+      end.to raise_error(Taro::ArgumentError, /null/)
+    end
+
+    it 'raises for unsupported options' do
+      expect do
+        subject.add_return code: 200, type: 'String', foobar: true
+      end.to raise_error(Taro::ArgumentError, /foobar/)
     end
   end
 

--- a/spec/taro/rails/response_validation_spec.rb
+++ b/spec/taro/rails/response_validation_spec.rb
@@ -1,15 +1,37 @@
 describe Taro::Rails::ResponseValidation do
-  it 'installs a before_action on the controller class, but only once' do
-    controller_class = Class.new
-    controller_class.define_singleton_method(:around_action) { |*| nil }
-    expect(controller_class).to receive(:around_action).once
-    2.times { described_class.install(controller_class:, action_name: :index) }
+  let(:controller_class) { Class.new }
+  let(:controller) { controller_class.new }
+  before { controller_class.define_method(:render) { |*| :original_result } }
+
+  describe '::install' do
+    it 'installs a validation on the controller class, but only once' do
+      expect { 2.times { described_class.install(controller_class:) } }
+        .to change { controller_class.ancestors.count { |a| a == described_class } }
+        .from(0).to(1)
+    end
+
+    it 'does not install the validation if it is disabled', config: { validate_response: false } do
+      described_class.install(controller_class:)
+      expect(controller_class.ancestors).not_to include(described_class)
+    end
   end
 
-  it 'does not install the around_action if param parsing is disabled', config: { validate_response: false } do
-    controller_class = Class.new
-    controller_class.define_singleton_method(:around_action) { |*| nil }
-    expect(controller_class).not_to receive(:around_action)
-    described_class.install(controller_class:, action_name: :index)
+  describe '#render' do
+    it 'patches Controller#render to call the ResponseValidator' do
+      described_class.install(controller_class:)
+      allow(Taro::Rails).to receive(:declaration_for).and_return(:decl)
+
+      expect(Taro::Rails::ResponseValidator)
+        .to receive(:call).with(controller, :decl, :json_arg)
+      expect(controller.render(json: :json_arg)).to eq(:original_result)
+    end
+
+    it 'does not call the ResponseValidator if the endpoint is undeclared' do
+      described_class.install(controller_class:)
+      allow(Taro::Rails).to receive(:declaration_for).and_return(nil)
+
+      expect(Taro::Rails::ResponseValidator).not_to receive(:call)
+      expect(controller_class.new.render(json: :json_arg)).to eq(:original_result)
+    end
   end
 end

--- a/spec/taro/rails/response_validator_spec.rb
+++ b/spec/taro/rails/response_validator_spec.rb
@@ -1,0 +1,154 @@
+describe Taro::Rails::ResponseValidator do
+  let(:controller) { double(class: 'Foo', action_name: 'bar', status: 200) }
+  let(:declaration) { Taro::Rails::Declaration.new }
+  let(:err) { Taro::ResponseError }
+
+  def test(arg)
+    described_class.call(controller, declaration, arg)
+  end
+
+  it 'can pass' do
+    declaration.add_return(code: 200, type: 'String')
+    expect { test('str') }.not_to raise_error
+  end
+
+  it 'can pass for nested responses' do
+    declaration.add_return(:nest, code: 200, type: 'String')
+    expect { test(nest: 'str') }.not_to raise_error
+  end
+
+  it 'can pass for nested responses with string key' do
+    declaration.add_return(:nest, code: 200, type: 'String')
+    expect { test('nest' => 'str') }.not_to raise_error
+  end
+
+  it 'can pass for array responses' do
+    declaration.add_return(code: 200, array_of: 'String')
+    expect { test(['str']) }.not_to raise_error
+  end
+
+  it 'can pass for empty array responses' do
+    declaration.add_return(code: 200, array_of: 'String')
+    expect { test([]) }.not_to raise_error
+  end
+
+  it 'can pass for nested array responses' do
+    declaration.add_return(:nest, code: 200, array_of: 'String')
+    expect { test(nest: ['str']) }.not_to raise_error
+  end
+
+  it 'can pass for booleans' do
+    declaration.add_return(code: 200, type: 'Boolean')
+    expect { test(true) }.not_to raise_error
+  end
+
+  it 'can pass for numbers' do
+    declaration.add_return(code: 200, type: 'Integer')
+    expect { test(42) }.not_to raise_error
+  end
+
+  it 'can pass for symbols used as strings' do
+    declaration.add_return(code: 200, type: 'String')
+    expect { test(:str) }.not_to raise_error
+  end
+
+  it 'can pass for enum types' do
+    stub_const('MyEnum', Class.new(T::EnumType))
+    MyEnum.value 'str'
+    declaration.add_return(code: 200, type: 'MyEnum')
+    expect { test('str') }.not_to raise_error
+  end
+
+  it 'can pass for object types' do
+    stub_const('MyObj', Class.new(T::ObjectType))
+    MyObj.field(:bar, type: 'String', null: false)
+    declaration.add_return(code: 200, type: 'MyObj')
+    result = MyObj.render(bar: 'baz')
+
+    expect { test(result) }.not_to raise_error
+  end
+
+  it 'can pass for FreeForm' do
+    declaration.add_return(code: 200, type: 'FreeForm')
+    expect { test(foo: 'bar') }.not_to raise_error
+  end
+
+  it 'can pass for NoContent' do
+    declaration.add_return(code: 200, type: 'NoContent')
+    expect { test({}) }.not_to raise_error
+  end
+
+  it 'fails when given nil' do
+    declaration.add_return(code: 200, type: 'String')
+    expect { test(nil) }.to raise_error(err, /Expected a string/)
+  end
+
+  it 'fails when given the wrong scalar' do
+    declaration.add_return(code: 200, type: 'String')
+    expect { test(42) }.to raise_error(err, /Expected a string/)
+  end
+
+  it 'fails when given the wrong scalar in an array' do
+    declaration.add_return(code: 200, array_of: 'String')
+    expect { test([42]) }.to raise_error(err, /Expected a string/)
+  end
+
+  it 'fails when given a non-array as an array' do
+    declaration.add_return(code: 200, array_of: 'String')
+    expect { test('str') }.to raise_error(err, /Expected an Array/)
+  end
+
+  it 'fails when not given the declared nesting' do
+    declaration.add_return(:nest, code: 200, type: 'String')
+    expect { test('str') }.to raise_error(err, /Expected Hash, got String/)
+  end
+
+  it 'fails when given a different than the declared nesting' do
+    declaration.add_return(:nest, code: 200, type: 'String')
+    expect { test(x: 'str') }.to raise_error(err, /Expected key :nest, got: \[:x\]/)
+  end
+
+  it 'fails for enum types if given a non-enum value' do
+    stub_const('MyEnum', Class.new(T::EnumType))
+    MyEnum.value 'str'
+    declaration.add_return(code: 200, type: 'MyEnum')
+    expect { test('OTHER') }.to raise_error(err, /must be "str"/)
+  end
+
+  it 'fails for object types if render was not called' do
+    stub_const('MyObj', Class.new(T::ObjectType))
+    MyObj.field(:bar, type: 'String', null: false)
+    declaration.add_return(code: 200, type: 'MyObj')
+
+    expect { test(bar: 'baz') }.to raise_error(err, /Expected to use MyObj.render/)
+  end
+
+  it 'fails for object types if render was called on another type' do
+    stub_const('MyObj', Class.new(T::ObjectType))
+    MyObj.field(:bar, type: 'String', null: false)
+    declaration.add_return(code: 200, type: 'MyObj')
+    S::StringType.render('baz')
+
+    expect { test(bar: 'baz') }.to raise_error(err, /Expected to use MyObj.render/)
+  end
+
+  it 'fails for object types if the render result was not used' do
+    stub_const('MyObj', Class.new(T::ObjectType))
+    MyObj.field(:bar, type: 'String', null: false)
+    declaration.add_return(code: 200, type: 'MyObj')
+    _result = MyObj.render(bar: 'baz')
+
+    expect { test(bar: 'baz') }.to raise_error(err, /not used in the response/)
+  end
+
+  it 'fails when given a non-standard openapi_type' do
+    declaration.add_return(code: 200, type: 'String')
+    allow(declaration.returns[200]).to receive(:openapi_type).and_return(:foo)
+    expect { test('str') }.to raise_error(err, /Expected a foo/)
+  end
+
+  it 'fails when given a status for which no return type is declared' do
+    declaration.add_return(code: 204, type: 'String')
+    expect { test('str') }.to raise_error(err, /No return type declared for this status/)
+  end
+end

--- a/spec/taro/types/coercion_spec.rb
+++ b/spec/taro/types/coercion_spec.rb
@@ -2,10 +2,14 @@ describe Taro::Types::Coercion do
   describe '::call' do
     %w[
       Boolean
+      Date
+      DateTime
       Float
       FreeForm
       Integer
+      NoContent
       String
+      Time
       Timestamp
       UUID
     ].each do |type|

--- a/spec/taro/types/enum_type_spec.rb
+++ b/spec/taro/types/enum_type_spec.rb
@@ -17,13 +17,13 @@ describe Taro::Types::EnumType do
   it 'coerces input' do
     expect(example.new('foo').coerce_input).to eq 'foo'
     expect { example.new('qux').coerce_input }
-      .to raise_error(Taro::InputError, '"qux" (String) is not valid as MyEnum: must be one of ["foo", "bar"]')
+      .to raise_error(Taro::InputError, '"qux" (String) is not valid as MyEnum: must be "foo" or "bar"')
   end
 
   it 'coerces response data' do
     expect(example.new('foo').coerce_response).to eq 'foo'
     expect { example.new('qux').coerce_response }
-      .to raise_error(Taro::ResponseError, '"qux" (String) is not valid as MyEnum: must be one of ["foo", "bar"]')
+      .to raise_error(Taro::ResponseError, '"qux" (String) is not valid as MyEnum: must be "foo" or "bar"')
   end
 
   it 'raises for empty enums' do

--- a/spec/taro/types/shared/rendering_spec.rb
+++ b/spec/taro/types/shared/rendering_spec.rb
@@ -13,11 +13,6 @@ describe Taro::Types::Shared::Rendering do
 
   it 'keeps track of the type used for rendering' do
     test_type.render('foo')
-    expect(T::BaseType.rendering).to eq(test_type)
-  end
-
-  it 'raises if called multiple times (DoubleRendering)' do
-    test_type.render('foo')
-    expect { test_type.render('foo') }.to raise_error(Taro::RuntimeError)
+    expect(T::BaseType.used_in_response).to eq(test_type)
   end
 end


### PR DESCRIPTION
- remove double render check, instead check that render result is passed to controller#render
- allow responding with scalar and enum values without rendering them through type classes
- correctly handle response nesting
- `::returns` no longer silently accepts kwargs that do nothing