### PR TITLE
Allow passing a custom proc as `:method` to `field`

### DIFF
--- a/lib/taro/types/field.rb
+++ b/lib/taro/types/field.rb
@@ -50,6 +50,8 @@ Taro::Types::Field = Data.define(:name, :type, :null, :method, :default, :enum, 
       context.public_send(method)
     elsif object_is_hash
       retrieve_hash_value(object)
+    elsif method.is_a?(Proc)
+      method.call(object)
     elsif object.respond_to?(method, true)
       object.public_send(method)
     else

--- a/spec/taro/types/field_spec.rb
+++ b/spec/taro/types/field_spec.rb
@@ -30,6 +30,11 @@ describe Taro::Types::Field do
       expect(field.value_for_response('low', object_is_hash: false)).to eq('LOW')
     end
 
+    it 'can use :method to call a custom proc' do
+      field = described_class.new(name: :foo, type: S::StringType, null: false, method: ->(v) { "Wrapped: #{v}" })
+      expect(field.value_for_response('low', object_is_hash: false)).to eq('Wrapped: low')
+    end
+
     it 'fetches value from context if defined directly on it' do
       context = Class.new(T::ObjectType).tap { |o| o.define_method(:upcase) { 'CTX' } }.new(nil)
       field = described_class.new(name: :upcase, type: S::StringType, null: false)


### PR DESCRIPTION
This is a proof of concept and could be implemented with different API (see below), I just want to check if this makes sense. I couldn't find a way to customize the output of a field, other than calling a method. Should this be done in a different way?

### Alternative APIs

* Same but with a different key than `method:` (e.g.: `proc:`)
* Passing an optional block to field:

```ruby
field :something, type: 'String' do |object|
  "Wrapped: #{object.something}"
end
```

### Pending

- [ ] Add documentation