### PR TITLE
Don't add null values because null is allowed

### DIFF
--- a/lib/taro/types/shared/object_coercion.rb
+++ b/lib/taro/types/shared/object_coercion.rb
@@ -2,7 +2,8 @@
 module Taro::Types::Shared::ObjectCoercion
   def coerce_input
     validate_no_undeclared_params
-    self.class.fields.transform_values do |field|
+    fields = self.class.fields.select { |key, definition| object.to_h.keys.include?(key) || definition.null == false || definition.default_specified? }
+    fields.transform_values do |field|
       field.value_for_input(object)
     end
   end

--- a/lib/taro/types/shared/object_coercion.rb
+++ b/lib/taro/types/shared/object_coercion.rb
@@ -2,10 +2,13 @@
 module Taro::Types::Shared::ObjectCoercion
   def coerce_input
     validate_no_undeclared_params
-    fields = self.class.fields.select { |key, definition| object.to_h.keys.include?(key) || definition.null == false || definition.default_specified? }
-    fields.transform_values do |field|
-      field.value_for_input(object)
+    result = {}
+    self.class.fields.each do |key, field|
+      next if field.null && !field.default_specified? && !object.key?(key)
+
+      result[key] = field.value_for_input(object)
     end
+    result
   end
 
   # Render the object into a hash.

--- a/spec/taro/rails/integration_spec.rb
+++ b/spec/taro/rails/integration_spec.rb
@@ -12,6 +12,7 @@ describe 'Rails integration' do
 
     # do all the things needed to run the controller, phew ...
     extend ActionController::TestCase::Behavior
+
     allow(self.class).to receive(:controller_class).and_return(users_controller)
     @routes = ::ActionDispatch::Routing::RouteSet.new
     @routes.draw { put '/users', to: 'users#update' }

--- a/spec/taro/rails/param_parsing_spec.rb
+++ b/spec/taro/rails/param_parsing_spec.rb
@@ -23,7 +23,7 @@ describe Taro::Rails::ParamParsing do
       stub_const('UserInputType', Class.new(T::InputType) do
         field :name, type: 'String', null: false
       end)
-      declaration.add_param :user, type: 'UserInputType', null: true
+      declaration.add_param :user, type: 'UserInputType', null: true, default: nil
       allow(Taro::Rails).to receive(:declaration_for).and_return(declaration)
       described_class.install(controller_class:, action_name: :index)
 

--- a/spec/taro/types/object_type_spec.rb
+++ b/spec/taro/types/object_type_spec.rb
@@ -2,7 +2,8 @@ describe Taro::Types::ObjectType do
   before do
     stub_const('ExampleObjectType', Class.new(Taro::Types::ObjectType) do
       field :foo, type: 'String', null: false
-      field :bar, type: 'String', null: true
+      field :bar, type: 'String', null: true, default: nil # adds a null value if not passed one
+      field :baz, type: 'String', null: true # allows null if passed but doesn't add it if not
     end)
   end
 
@@ -11,18 +12,18 @@ describe Taro::Types::ObjectType do
   end
 
   it 'coerces response data' do
-    expect(ExampleObjectType.new({ foo: 'FOO' }).coerce_response).to eq(foo: 'FOO', bar: nil)
+    expect(ExampleObjectType.new({ foo: 'FOO' }).coerce_response).to eq(foo: 'FOO', bar: nil, baz: nil)
   end
 
   it 'can coerce input data differently than response data (e.g. more strictly)' do
     expect { ExampleObjectType.new({ foo: :FOO }).coerce_input }
       .to raise_error(Taro::InputError, /must be a String/)
-    expect(ExampleObjectType.new({ foo: :FOO }).coerce_response).to eq(foo: 'FOO', bar: nil)
+    expect(ExampleObjectType.new({ foo: :FOO }).coerce_response).to eq(foo: 'FOO', bar: nil, baz: nil)
   end
 
   it 'coerces objects as response data' do
-    obj = Struct.new(:foo, :bar).new('FOO', nil)
-    expect(ExampleObjectType.new(obj).coerce_response).to eq(foo: 'FOO', bar: nil)
+    obj = Struct.new(:foo, :bar, :baz).new('FOO', nil, nil)
+    expect(ExampleObjectType.new(obj).coerce_response).to eq(foo: 'FOO', bar: nil, baz: nil)
   end
 
   it 'works recursively' do
@@ -30,6 +31,6 @@ describe Taro::Types::ObjectType do
       field :qux, type: 'ExampleObjectType', null: false
     end
 
-    expect(nested.new({ qux: { foo: 'FOO' } }).coerce_response).to eq(qux: { foo: 'FOO', bar: nil })
+    expect(nested.new({ qux: { foo: 'FOO' } }).coerce_response).to eq(qux: { foo: 'FOO', bar: nil, baz: nil })
   end
 end


### PR DESCRIPTION
Change what `null: true` means: null values are allowed, but that doesn't mean it's the default if no value is passed. I'm not familiar with the code base so there's probably a better way to do it. Consider it work in progress because of that but also because of the two pending tasks.

This is a breaking change. To retain the old behaviour you need to specify `null: true, default: nil`.

Pending:

- [ ] Add this somewhere in the documentation
- [x] Decide how this should apply to _output_ types